### PR TITLE
Switch to using google's STUN server

### DIFF
--- a/server/client/main.js
+++ b/server/client/main.js
@@ -15,7 +15,7 @@ var peer;
 var localStream;
 
 // must use 'url' here since Firefox doesn't understand 'urls'
-var configuration = { "iceServers": [{ "url": "stun:132.177.123.6" }] };
+var configuration = { "iceServers": [{ "url": "stun:stun.l.google.com:19302" }] };
 
 window.onload = function () {
     remoteView = document.getElementById("remote_view");


### PR DESCRIPTION
stun:132.177.123.6 doesn't seem to work anymore. This patch depends on https://github.com/EricssonResearch/openwebrtc-build-scripts/pull/14
