### PR TITLE
web/client/: Fixed bug where text entered after "<" would disappear.

### DIFF
--- a/web/client/main.js
+++ b/web/client/main.js
@@ -288,7 +288,7 @@ function setupChat() {
         var messageNode = document.createElement('div');
         var messageContent = document.createElement('div');
         messageNode.classList.add('chatMessage');
-        messageContent.innerHTML = msg;
+        messageContent.textContent = msg;
         messageNode.appendChild(messageContent);
 
         if (author) {


### PR DESCRIPTION
After entering "<" and then text - message would disappear. Because the browser interprets it as unknown tag (InnerHTML).