### PR TITLE
Update example applications to make correct use of owr_init and owr_run_in_background

### DIFF
--- a/ios/Selfie/Selfie/SelfViewController.m
+++ b/ios/Selfie/Selfie/SelfViewController.m
@@ -64,8 +64,9 @@ OwrVideoRenderer *renderer;
 {
     [super viewDidLoad];
 
-    owr_init();
+    owr_init(NULL);
     NSLog(@"OpenWebRTC initialized");
+    owr_run_in_background();
 
     NSLog(@"Registering self view %@", self.selfView);
     owr_window_registry_register(owr_window_registry_get(), SELF_VIEW_TAG, (__bridge gpointer)(self.selfView));

--- a/osx/Camera Test/Camera Test/AppDelegate.m
+++ b/osx/Camera Test/Camera Test/AppDelegate.m
@@ -76,8 +76,9 @@ static void got_sources(GList *sources, gpointer user_data)
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     // Insert code here to initialize your application
 
-    owr_init();
+    owr_init(NULL);
     NSLog(@"OpenWebRTC initialized");
+    owr_run_in_background();
 
     NSLog(@"Registering self view %@", self.selfView);
     owr_window_registry_register(owr_window_registry_get(), SELF_VIEW_TAG, (__bridge gpointer)(self.selfView));


### PR DESCRIPTION
`owr_init` has been modified and the previous plain `owr_init()` behaviour is now present through `owr_init(); owr_run_in_background();`