### PR TITLE
easier install. A pod install will then just work

### DIFF
--- a/ios/NativeDemo/Podfile
+++ b/ios/NativeDemo/Podfile
@@ -2,9 +2,9 @@ platform :ios, '8.0'
 
 target 'NativeDemo' do
     pod 'InAppSettingsKit', '~> 2.4.4'
-    pod 'OpenWebRTC-SDK',  :git => 'https://github.com/evermeer/openwebrtc-ios-sdk.git'
+    pod 'OpenWebRTC-SDK',  :git => 'https://github.com/EricssonResearch/openwebrtc-examples.git'
 end
 
 target 'NativeDemoTests' do
-    pod 'OpenWebRTC-SDK',  :git => 'https://github.com/evermeer/openwebrtc-ios-sdk.git'
+    pod 'OpenWebRTC-SDK',  :git => 'https://github.com/EricssonResearch/openwebrtc-examples.git'
 end

--- a/ios/NativeDemo/Podfile
+++ b/ios/NativeDemo/Podfile
@@ -2,9 +2,9 @@ platform :ios, '8.0'
 
 target 'NativeDemo' do
     pod 'InAppSettingsKit', '~> 2.4.4'
-    pod 'OpenWebRTC-SDK',  :git => 'https://github.com/EricssonResearch/openwebrtc-examples.git'
+    pod 'OpenWebRTC-SDK',  :git => ' https://github.com/EricssonResearch/openwebrtc-ios-sdk.git'
 end
 
 target 'NativeDemoTests' do
-    pod 'OpenWebRTC-SDK',  :git => 'https://github.com/EricssonResearch/openwebrtc-examples.git'
+    pod 'OpenWebRTC-SDK',  :git => ' https://github.com/EricssonResearch/openwebrtc-ios-sdk.git'
 end

--- a/ios/NativeDemo/Podfile
+++ b/ios/NativeDemo/Podfile
@@ -2,9 +2,9 @@ platform :ios, '8.0'
 
 target 'NativeDemo' do
     pod 'InAppSettingsKit', '~> 2.4.4'
-    pod 'OpenWebRTC-SDK', :path => '../../../openwebrtc-ios-sdk/OpenWebRTC-SDK.podspec'
+    pod 'OpenWebRTC-SDK',  :git => 'https://github.com/evermeer/openwebrtc-ios-sdk.git'
 end
 
 target 'NativeDemoTests' do
-    pod 'OpenWebRTC-SDK', :path => '../../../openwebrtc-ios-sdk/OpenWebRTC-SDK.podspec'
+    pod 'OpenWebRTC-SDK',  :git => 'https://github.com/evermeer/openwebrtc-ios-sdk.git'
 end


### PR DESCRIPTION
There is no need to first clone the openwebrtc-ios-sdk. When changing to this line a 'pod install' will just work