### PR TITLE
web, NativeDemo: fix signalling

### DIFF
--- a/ios/NativeDemo/NativeDemo/NativeDemoViewController.m
+++ b/ios/NativeDemo/NativeDemo/NativeDemoViewController.m
@@ -200,8 +200,7 @@
 {
     NSLog(@"Answer generated: \n%@", answer);
 
-    NSDictionary *d = @{@"sdp": answer};
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:d
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:answer
                                                        options:NSJSONWritingPrettyPrinted
                                                          error:nil];
     NSString *answerString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
@@ -215,8 +214,7 @@
 {
     NSLog(@"Offer generated: \n%@", offer);
 
-    NSDictionary *d = @{@"sdp": offer};
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:d
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:offer
                                                        options:NSJSONWritingPrettyPrinted
                                                          error:nil];
     NSString *offerString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
@@ -230,8 +228,12 @@
 {
     NSLog(@"Candidate generated: \n%@", candidate);
     if (self.peerID) {
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:@{@"candidate": @{@"candidate": candidate}}
+                                                           options:NSJSONWritingPrettyPrinted
+                                                             error:nil];
+        NSString *candidateJson = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
         NSLog(@"Sending candidate to peer: %@", self.peerID);
-        [self.peerServer sendMessage:candidate toPeer:self.peerID];
+        [self.peerServer sendMessage:candidateJson toPeer:self.peerID];
     }
 }
 

--- a/ios/NativeDemo/NativeDemo/PeerServerHandler.m
+++ b/ios/NativeDemo/NativeDemo/PeerServerHandler.m
@@ -104,9 +104,9 @@
         if (json[@"sdp"]) {
             NSString *type = json[@"type"];
             if ([@"offer" isEqualToString:type]) {
-                [self.delegate peerServer:self peer:peerUser sentOffer:json[@"sdp"][@"sdp"]];
+                [self.delegate peerServer:self peer:peerUser sentOffer:json[@"sdp"]];
             } else if ([@"answer" isEqualToString:type]) {
-                [self.delegate peerServer:self peer:peerUser sentAnswer:json[@"sdp"][@"sdp"]];
+                [self.delegate peerServer:self peer:peerUser sentAnswer:json[@"sdp"]];
             } else {
                 NSLog(@"[PeerServerHandler] WARNING! Got malformed offer/answer from peer");
             }

--- a/web/client/main.js
+++ b/web/client/main.js
@@ -172,10 +172,7 @@ function handleMessage(evt) {
         start(false);
 
     if (message.sessionDescription || message.sdp) {
-        var desc = new RTCSessionDescription({
-            "sdp": SDP.generate(message.sessionDescription) || message.sdp,
-            "type": message.type
-        });
+        var desc = new RTCSessionDescription(message);
         pc.setRemoteDescription(desc, function () {
             // if we received an offer, we need to create an answer
             if (pc.remoteDescription.type == "offer")


### PR DESCRIPTION
Signaling was broken by 8f7b847b5f2d0a267ef1eaea5f8b2f405af6a120. This commit
makes it work again, fixing a bug in the js signalling code and updating
NativeDemo to work with the new message formats expected by the signaling
server.