### PR TITLE
Update Info.plist, add NSCameraUsageDescription & NSMicrophoneUsageDescription

### DIFF
--- a/ios/NativeDemo/NativeDemo/Info.plist
+++ b/ios/NativeDemo/NativeDemo/Info.plist
@@ -22,6 +22,10 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>OpenWebRTC NativeDemo get Video</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>OpenWebRTC NativeDemo get Audio</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
To protect user privacy, an iOS app linked on or after iOS 10.0, and that accesses any of the device’s cameras and/or microphones, must statically declare the intent to do so.
Reference: https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24