### PR TITLE
Fix request/response race condition. 

### DIFF
--- a/web/channel_server.js
+++ b/web/channel_server.js
@@ -123,14 +123,15 @@ function requestListener(request, response) {
             request.on("end", function () {
                 console.log("@" + sessionId + " - " + userId + " => " + peerId + " :");
                 // console.log(body);
+
+                // to avoid "no element found" warning in Firefox (bug 521301)
+                headers["Content-Type"] = "text/plain";
+                response.writeHead(204, headers);
+                response.end();
+
                 var evtdata = "data:" + body.replace(/\n/g, "\ndata:") + "\n";
                 peer.esResponse.write("event:user-" + userId + "\n" + evtdata + "\n");
             });
-
-            // to avoid "no element found" warning in Firefox (bug 521301)
-            headers["Content-Type"] = "text/plain";
-            response.writeHead(204, headers);
-            response.end();
         }
 
         return;


### PR DESCRIPTION
In the `ctos` handling section of the server, there is a race condition exhibited on some systems. If the response is sent (with the response.end call), sometimes the "data" and "end" callbacks for the body are not called. This results in a loss of the body content and prevents the peer-to-peer connection from being created. This is particularly exhibited when running the server in Node JS on Heroku. 